### PR TITLE
Fixes for dlib test failures

### DIFF
--- a/dlib/assert.h
+++ b/dlib/assert.h
@@ -27,18 +27,30 @@
 #endif
 
 // figure out if the compiler has rvalue references. 
-#if defined(__clang__) 
+#if defined(__clang__)
 #   if __has_feature(cxx_rvalue_references)
 #       define DLIB_HAS_RVALUE_REFERENCES
 #   endif
+#   if __has_feature(cxx_generalized_initializers)
+#       define DLIB_HAS_INITIALIZER_LISTS
+#   endif
 #elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2)) && defined(__GXX_EXPERIMENTAL_CXX0X__) 
+#   define DLIB_HAS_RVALUE_REFERENCES
+#   define DLIB_HAS_INITIALIZER_LISTS
+#elif defined(_MSC_VER) && _MSC_VER >= 1800
+#   define DLIB_HAS_INITIALIZER_LISTS
 #   define DLIB_HAS_RVALUE_REFERENCES
 #elif defined(_MSC_VER) && _MSC_VER >= 1600
 #   define DLIB_HAS_RVALUE_REFERENCES
 #elif defined(__INTEL_COMPILER) && defined(BOOST_INTEL_STDCXX0X)
 #   define DLIB_HAS_RVALUE_REFERENCES
+#   define DLIB_HAS_INITIALIZER_LISTS
 #endif
 
+#if defined(__APPLE__) && defined(__GNUC_LIBSTD__) && ((__GNUC_LIBSTD__-0) * 100 + __GNUC_LIBSTD_MINOR__-0 <= 402)
+ // Apple has not updated libstdc++ in some time and anything under 4.02 does not have <initializer_list> for sure.
+#   undef DLIB_HAS_INITIALIZER_LISTS
+#endif
 
 // figure out if the compiler has static_assert. 
 #if defined(__clang__) 

--- a/dlib/matrix/matrix.h
+++ b/dlib/matrix/matrix.h
@@ -16,7 +16,7 @@
 #include "matrix_assign_fwd.h"
 #include "matrix_op.h"
 #include <utility>
-#ifdef DLIB_HAS_RVALUE_REFERENCES
+#ifdef DLIB_HAS_INITIALIZER_LISTS
 #include <initializer_list>
 #endif
 
@@ -1114,7 +1114,7 @@ namespace dlib
             matrix_assign(*this, m);
         }
 
-#ifdef DLIB_HAS_RVALUE_REFERENCES
+#ifdef DLIB_HAS_INITIALIZER_LISTS
         matrix(const std::initializer_list<T>& l)
         {
             if (NR*NC != 0)
@@ -1169,7 +1169,9 @@ namespace dlib
             temp.swap(*this);
             return *this;
         }
+#endif // DLIB_HAS_INITIALIZER_LISTS
 
+#ifdef DLIB_HAS_RVALUE_REFERENCES
         matrix(matrix&& item)
         {
         #ifdef MATLAB_MEX_FILE
@@ -1210,7 +1212,7 @@ namespace dlib
         #endif
             return *this;
         }
-#endif
+#endif // DLIB_HAS_RVALUE_REFERENCES
 
         template <typename U, size_t len>
         explicit matrix (


### PR DESCRIPTION
This a possible fix for the VS2012 compile error, still looking into clang will add it once I figure it out.