### PR TITLE
Fixes for iOS (and others)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.0)
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.16.15.tar.gz"
-    SHA1 "6974c2150fc0d3b09de3ad1efcbf15d360647ffa"
+    URL "https://github.com/ruslo/hunter/archive/v0.19.84.tar.gz"
+    SHA1 "9086d4b3c32784effdd6f83f45125b55cf95aae8"
 )
 
 project(dlib VERSION 19.4)

--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -62,28 +62,30 @@ if (UNIX OR MINGW)
         return()
     endif()
 
-    include(CheckTypeSize)
-    check_type_size( "void*" SIZE_OF_VOID_PTR)
+    if(NOT CMAKE_CROSSCOMPILING)
+        include(CheckTypeSize)
+        check_type_size( "void*" SIZE_OF_VOID_PTR)
 
-    if (SIZE_OF_VOID_PTR EQUAL 8)
-        set( mkl_search_path
-            /opt/intel/mkl/*/lib/em64t
-            /opt/intel/mkl/lib/intel64
-            /opt/intel/lib/intel64
+        if (SIZE_OF_VOID_PTR EQUAL 8)
+            set( mkl_search_path
+                /opt/intel/mkl/*/lib/em64t
+                /opt/intel/mkl/lib/intel64
+                /opt/intel/lib/intel64
             )
 
-        find_library(mkl_intel mkl_intel_lp64 ${mkl_search_path})
-        mark_as_advanced(mkl_intel)
-    else()
-        set( mkl_search_path
-            /opt/intel/mkl/*/lib/32
-            /opt/intel/mkl/lib/ia32
-            /opt/intel/lib/ia32
+            find_library(mkl_intel mkl_intel_lp64 ${mkl_search_path})
+            mark_as_advanced(mkl_intel)
+        else()
+            set( mkl_search_path
+                /opt/intel/mkl/*/lib/32
+                /opt/intel/mkl/lib/ia32
+                /opt/intel/lib/ia32
             )
 
-        find_library(mkl_intel mkl_intel ${mkl_search_path})
-        mark_as_advanced(mkl_intel)
-    endif()
+            find_library(mkl_intel mkl_intel ${mkl_search_path})
+            mark_as_advanced(mkl_intel)
+        endif()
+    endif()`
 
    include(CheckLibraryExists)
 

--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -85,7 +85,7 @@ if (UNIX OR MINGW)
             find_library(mkl_intel mkl_intel ${mkl_search_path})
             mark_as_advanced(mkl_intel)
         endif()
-    endif()`
+    endif()
 
    include(CheckLibraryExists)
 
@@ -156,7 +156,13 @@ if (UNIX OR MINGW)
    INCLUDE (CheckFunctionExists)
 
    if (NOT blas_found)
-      find_library(cblas_lib openblas PATHS ${extra_paths})
+      if (NOT IOS OR WIN32)
+          hunter_add_package(OpenBLAS)
+          find_package(OpenBLAS CONFIG REQUIRED)
+          set(cblas_lib OpenBLAS::OpenBLAS)
+      else()
+          find_library(cblas_lib openblas PATHS ${extra_paths})
+      endif()
       if (cblas_lib)
          set(blas_libraries ${cblas_lib})
          set(blas_found 1)


### PR DESCRIPTION
Don't use CheckTypeSize for cross-compile (assume doesn't exist).
Use hunter OpenBLAS instead of searching for it, if hunter supports the platform.