### PR TITLE
Lost the actual lib link

### DIFF
--- a/dlib/CMakeLists.txt
+++ b/dlib/CMakeLists.txt
@@ -612,6 +612,7 @@ if (NOT TARGET dlib)
                               INTERFACE $<INSTALL_INTERFACE:include>
                               ${dlib_keyword} ${dlib_needed_includes}
                               )
+   target_link_libraries(dlib PUBLIC ${dlib_needed_libraries})
    if (DLIB_IN_PROJECT_BUILD)
       target_compile_options(dlib ${dlib_keyword} ${active_preprocessor_switches})
    elseif(NOT DLIB_HEADER_ONLY)


### PR DESCRIPTION
Sorry about missing this one! No idea how it compiled locally.

Also running tests, merged in pkg.dlib, simultaneously:
https://travis-ci.org/xsacha/hunter/builds/357186104
https://ci.appveyor.com/project/xsacha/hunter-h4uji